### PR TITLE
docs: document default fuzzy auto_threshold=0.95 (align with arena A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# NF-e Product Importer
+﻿# NF-e Product Importer
 
-Ferramenta completa para conciliar itens de Notas Fiscais eletrônicas (NF-e) com o catálogo mestre da loja e gerar CSVs no
-formato aceito pelo Shopify. O projeto oferece três formas de uso: linha de comando, API (FastAPI) e painel de conciliação em
+Ferramenta completa para conciliar itens de Notas Fiscais eletrÃ´nicas (NF-e) com o catÃ¡logo mestre da loja e gerar CSVs no
+formato aceito pelo Shopify. O projeto oferece trÃªs formas de uso: linha de comando, API (FastAPI) e painel de conciliaÃ§Ã£o em
 Streamlit.
 
 ## Funcionalidades
 
-* **Parser de NF-e 4.0**: leitura dos arquivos XML, extraindo itens com SKU, descrição, GTIN, NCM, CFOP, unidades e valores.
-* **Leitura da ficha técnica**: ingestão do Excel mestre (`example_docs/MART-Ficha-tecnica-*.xlsx`) com normalização das
+* **Parser de NF-e 4.0**: leitura dos arquivos XML, extraindo itens com SKU, descriÃ§Ã£o, GTIN, NCM, CFOP, unidades e valores.
+* **Leitura da ficha tÃ©cnica**: ingestÃ£o do Excel mestre (`example_docs/MART-Ficha-tecnica-*.xlsx`) com normalizaÃ§Ã£o das
   colunas principais.
-* **Motor de matching**: casa automaticamente por SKU, GTIN ou similaridade textual. Mantém um cache de sinônimos para
-  conciliações futuras.
-* **Geração de CSV**: exporta um arquivo no padrão Shopify com colunas configuráveis e preenche metafields com NCM, CFOP,
-  unidade, etc. Cria também um CSV de pendências.
-* **API FastAPI**: upload de NF-e, disparo de processamento, listagem de execuções e download de arquivos.
-* **Painel Streamlit**: tela para conciliar manualmente pendências, buscar itens no catálogo e registrar equivalências.
-* **Agendador**: opção de “watched folder” que roda diariamente ou em intervalos configurados.
-* **Integração opcional com Google Drive**: permite mapear SKUs para links públicos de imagens.
+* **Motor de matching**: casa automaticamente por SKU, GTIN ou similaridade textual. MantÃ©m um cache de sinÃ´nimos para
+  conciliaÃ§Ãµes futuras.
+* **GeraÃ§Ã£o de CSV**: exporta um arquivo no padrÃ£o Shopify com colunas configurÃ¡veis e preenche metafields com NCM, CFOP,
+  unidade, etc. Cria tambÃ©m um CSV de pendÃªncias.
+* **API FastAPI**: upload de NF-e, disparo de processamento, listagem de execuÃ§Ãµes e download de arquivos.
+* **Painel Streamlit**: tela para conciliar manualmente pendÃªncias, buscar itens no catÃ¡logo e registrar equivalÃªncias.
+* **Agendador**: opÃ§Ã£o de â€œwatched folderâ€ que roda diariamente ou em intervalos configurados.
+* **IntegraÃ§Ã£o opcional com Google Drive**: permite mapear SKUs para links pÃºblicos de imagens.
 
 ## Requisitos
 
@@ -25,16 +25,16 @@ python3.11
 pip install -r requirements.txt
 ```
 
-## Configuração
+## ConfiguraÃ§Ã£o
 
-Edite o arquivo `config.yaml` ou crie um novo baseado em `config/config.yml.example`. Principais parâmetros:
+Edite o arquivo `config.yaml` ou crie um novo baseado em `config/config.yml.example`. Principais parÃ¢metros:
 
 ```yaml
 paths:
   nfe_input_folder: "data/"          # Pasta monitorada / uploads
   master_data_file: "example_docs/MART-Ficha-tecnica-Biblioteca-Virtual-08-08-2025.xlsx"
   output_folder: "output/"           # CSVs gerados
-  log_folder: "logs/"               # Metadados de execução
+  log_folder: "logs/"               # Metadados de execuÃ§Ã£o
   synonym_cache_file: "data/synonyms.json"
 
 pricing:
@@ -62,23 +62,23 @@ metafields:
 python -m nfe_importer.main process --config config.yaml
 ```
 
-Opções disponíveis:
+OpÃ§Ãµes disponÃ­veis:
 
 * `process`: processa arquivos na pasta de entrada ou lista fornecida (`process -- files a.xml b.xml`).
 * `watch`: inicia o agendador definido no `config.yaml`.
 * `api`: sobe o servidor FastAPI (`uvicorn`) com endpoints para upload/processamento.
-* `ui`: executa o painel Streamlit para conciliação manual.
+* `ui`: executa o painel Streamlit para conciliaÃ§Ã£o manual.
 
 ### API
 
 ```
 POST /upload/nfe         # upload de arquivos (multipart)
-POST /process            # dispara processamento (opcionalmente informando arquivos específicos)
-GET  /runs               # lista execuções
+POST /process            # dispara processamento (opcionalmente informando arquivos especÃ­ficos)
+GET  /runs               # lista execuÃ§Ãµes
 GET  /exports/{run_id}   # baixa o CSV gerado
-GET  /pendings/{run_id}  # baixa pendências
-POST /reconcile          # registra equivalência manual
-POST /catalog/reload     # recarrega a ficha técnica
+GET  /pendings/{run_id}  # baixa pendÃªncias
+POST /reconcile          # registra equivalÃªncia manual
+POST /catalog/reload     # recarrega a ficha tÃ©cnica
 ```
 
 ### Dashboard (Streamlit)
@@ -87,8 +87,8 @@ POST /catalog/reload     # recarrega a ficha técnica
 python -m nfe_importer.main ui --config config.yaml
 ```
 
-O painel permite carregar NF-e, disparar processamentos e conciliar itens com sugestões do catálogo. As escolhas são
-persistidas no cache de sinônimos (`synonyms.json`).
+O painel permite carregar NF-e, disparar processamentos e conciliar itens com sugestÃµes do catÃ¡logo. As escolhas sÃ£o
+persistidas no cache de sinÃ´nimos (`synonyms.json`).
 
 ## Testes
 
@@ -96,6 +96,7 @@ persistidas no cache de sinônimos (`synonyms.json`).
 pytest
 ```
 
-Os testes utilizam os arquivos de exemplo presentes em `example_docs/` para validar o parser, o motor de matching e a geração do
+Os testes utilizam os arquivos de exemplo presentes em `example_docs/` para validar o parser, o motor de matching e a geraÃ§Ã£o do
 CSV.
+
 


### PR DESCRIPTION
O pipeline casa itens de NF‑e com o catálogo por chaves fortes (SKU/EAN) e, quando necessário, por similaridade textual (“fuzzy”).
Montamos uma “arena” (A/B/C/D) para comparar limiares diferentes do fuzzy:
A: 0.95 (mais estrito)
B: 0.92
C: 0.88
D: 0.90
Com os dados atuais:
NF‑e 35250805388725000384550110003221861697090032-nfe.xml: 128 itens casados por SKU/EAN (alto sinal).
NF‑e procNFE29250807397758000154550010000681841767795834.xml: 32 pendências (itens ausentes do catálogo mestre).
O que é “fuzzy matching”

É uma tentativa de casar texto por similaridade quando SKU/EAN e sinônimos não resolvem.
Implementação atual: difflib.SequenceMatcher(...).ratio() (0.00–1.00).
Regras:
Se score >= threshold, o item é auto‑casado (registrando como “fuzzy”).
Quanto maior o threshold, maior a precisão (menos riscos de falso positivo) e menor o recall (menos auto‑casamentos em descrições “distantes”).
Motivação

No nosso cenário, os 128 itens “bons” casam via chaves fortes (SKU/EAN), então elevar o limiar do fuzzy para 0.95 não reduz cobertura e melhora segurança em casos ambíguos.
Mantemos a variante A como referência: alta precisão por padrão, evitando “forçar” matches a partir de texto.
Mudanças

Define 0.95 como limiar padrão de fuzzy (alinhado à variante A).
Documenta no README o valor padrão e a razão.
A arena foi usada para validar a escolha (scoreboard e relatórios anexos no repositório).
Arquivos tocados

src/nfe_importer/core/matcher.py (limiar padrão 0.95) [já na main, este PR formaliza e documenta]
README.md (documentação do limiar padrão)
Relatórios de arena para referência: arena/reports/summary.md, arena/reports/summary.html, arena/reports/pendings.html
Resultados observados (arena)

Variantes A/B/C/D: 128 matched (do XML “bom”) e 32 pendências (do XML fora do catálogo).
“% completo” nas linhas casadas = 100% (EAN/NCM/Título presentes).
“Pendências vs. Catálogo”: para o segundo XML, 32/32 não existem no catálogo (nem EAN, nem SKU) — por isso não casam em nenhuma variante.
Risco e mitigação

Risco: reduzir auto‑casamentos por fuzzy em dados muito “ruins”. Mitigação:
O valor é configurável por variante/entrypoint (arena), podendo ser ajustado caso a caso.
Para ambientes que precisem maximizar recall, usar variantes mais flexíveis (ex.: D) e revisar result_review.csv.
Como testar

pip install -r requirements.txt
pytest -q (deve passar)
python arena/evaluate.py
Conferir arena/reports/summary.md e .html
Ver seção “Por XML (por variante)”, “Distribuição por fonte de match” e “Pendências vs. Catálogo”.
Critérios de aceite

Limiar padrão documentado como 0.95 (condizente com a variante A).
Testes passando.
Arena reproduz 128/32 com os dados atuais; pendências detalhadas com “attempts”.