### PR TITLE
feat: melhorar export Shopify (peso, metafields, métricas) - Feature/shopify import fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
 ﻿# NF-e Product Importer
 
-Ferramenta completa para conciliar itens de Notas Fiscais eletrônicas (NF-e) com o catálogo mestre da loja e gerar CSVs no
-formato aceito pelo Shopify. O projeto oferece trás formas de uso: linha de comando, API (FastAPI) e painel de conciliaÃ§Ã£o em
-Streamlit.
+Ferramenta completa para conciliar itens de Notas Fiscais eletrônicas (NF-e) com o catálogo mestre da loja e gerar CSVs no formato aceito pelo Shopify. O projeto oferece três formas de uso: linha de comando, API (FastAPI) e painel de conciliação em Streamlit.
 
 ## Funcionalidades
 
-* **Parser de NF-e 4.0**: leitura dos arquivos XML, extraindo itens com SKU, descrição, GTIN, NCM, CFOP, unidades e valores.
-* **Leitura da ficha técnica**: ingestão do Excel mestre (`example_docs/MART-Ficha-tecnica-*.xlsx`) com normalização das
-  colunas principais.
-* **Motor de matching**: casa automaticamente por SKU, GTIN ou similaridade textual. MantÃ©m um cache de sinônimos para
-  conciliações futuras.
-* **Geração de CSV**: exporta um arquivo no padrÃ£o Shopify com colunas configuráveis e preenche metafields com NCM, CFOP,
-  unidade, etc. Cria também um CSV de pendências.
-* **API FastAPI**: upload de NF-e, disparo de processamento, listagem de execuções e download de arquivos.
-* **Painel Streamlit**: tela para conciliar manualmente pendências, buscar itens no catálogo e registrar equivalências.
-* **Agendador**: opÃ§Ã£o de â€œwatched folderâ€ que roda diariamente ou em intervalos configurados.
-* **Integração opcional com Google Drive**: permite mapear SKUs para links públicos de imagens.
+- **Parser de NF-e 4.0**: leitura dos arquivos XML, extraindo itens com SKU, descrição, GTIN, NCM, CFOP, unidades e valores.
+- **Leitura da ficha técnica**: ingestão do Excel mestre (`example_docs/MART-Ficha-tecnica-*.xlsx`) com normalização das colunas principais.
+- **Motor de matching**: casa automaticamente por SKU, GTIN ou similaridade textual. Mantém um cache de sinônimos para conciliações futuras.
+- **Geração de CSV**: exporta um arquivo no padrão Shopify com colunas configuráveis e preenche metafields com NCM, CFOP, unidade etc. Cria também um CSV de pendências.
+- **API FastAPI**: upload de NF-e, disparo de processamento, listagem de execuções e download de arquivos.
+- **Painel Streamlit**: tela para conciliar manualmente pendências, buscar itens no catálogo e registrar equivalências.
+- **Agendador**: opção de "watched folder" que roda diariamente ou em intervalos configurados.
+- **Integração opcional com Google Drive**: permite mapear SKUs para links públicos de imagens.
 
 ## Requisitos
 
@@ -25,7 +20,7 @@ python3.11
 pip install -r requirements.txt
 ```
 
-## ConfiguraÃ§Ã£o
+## Configuração
 
 Edite o arquivo `config.yaml` ou crie um novo baseado em `config/config.yml.example`. Principais parâmetros:
 
@@ -62,23 +57,23 @@ metafields:
 python -m nfe_importer.main process --config config.yaml
 ```
 
-OpÃ§Ãµes disponÃ­veis:
+Opções disponíveis:
 
-* `process`: processa arquivos na pasta de entrada ou lista fornecida (`process -- files a.xml b.xml`).
-* `watch`: inicia o agendador definido no `config.yaml`.
-* `api`: sobe o servidor FastAPI (`uvicorn`) com endpoints para upload/processamento.
-* `ui`: executa o painel Streamlit para conciliação manual.
+- `process`: processa arquivos na pasta de entrada ou lista fornecida (`process --files a.xml b.xml`).
+- `watch`: inicia o agendador definido no `config.yaml`.
+- `api`: sobe o servidor FastAPI (`uvicorn`) com endpoints para upload/processamento.
+- `ui`: executa o painel Streamlit para conciliação manual.
 
 ### API
 
 ```
 POST /upload/nfe         # upload de arquivos (multipart)
-POST /process            # dispara processamento (opcionalmente informando arquivos especÃ­ficos)
-GET  /runs               # lista execuÃ§Ãµes
+POST /process            # dispara processamento (opcionalmente informando arquivos específicos)
+GET  /runs               # lista execuções
 GET  /exports/{run_id}   # baixa o CSV gerado
-GET  /pendings/{run_id}  # baixa pendÃªncias
-POST /reconcile          # registra equivalÃªncia manual
-POST /catalog/reload     # recarrega a ficha tÃ©cnica
+GET  /pendings/{run_id}  # baixa pendências
+POST /reconcile          # registra equivalência manual
+POST /catalog/reload     # recarrega a ficha técnica
 ```
 
 ### Dashboard (Streamlit)
@@ -87,8 +82,7 @@ POST /catalog/reload     # recarrega a ficha tÃ©cnica
 python -m nfe_importer.main ui --config config.yaml
 ```
 
-O painel permite carregar NF-e, disparar processamentos e conciliar itens com sugestões do catálogo. As escolhas são
-persistidas no cache de sinônimos (`synonyms.json`).
+O painel permite carregar NF-e, disparar processamentos e conciliar itens com sugestões do catálogo. As escolhas são persistidas no cache de sinônimos (`synonyms.json`).
 
 ## Testes
 
@@ -96,47 +90,35 @@ persistidas no cache de sinônimos (`synonyms.json`).
 pytest
 ```
 
-Os testes utilizam os arquivos de exemplo presentes em `example_docs/` para validar o parser, o motor de matching e a geração do
-CSV.
+Os testes utilizam os arquivos de exemplo presentes em `example_docs/` para validar o parser, o motor de matching e a geração do CSV.
 
+### Selecionando versões no dashboard
 
-### Selecionando versoes no dashboard
+A UI agora lista automaticamente as configurações encontradas em `pipelines/**/config.yaml`. Cada versão (V1, V2, Enhanced, Super) aparece com o caminho da configuração ao lado. Basta abrir o painel com:
 
-A UI agora lista automaticamente as configuracoes encontradas em pipelines/**/config.yaml.
-Cada versao (V1, V2, Enhanced, Super) aparece com o caminho da configuracao ao lado. Basta
-abrir o painel com:
-
-`ash
+```bash
 python -m nfe_importer.main ui --config config.yaml
-`
+```
 
-Na barra lateral selecione a versao desejada, carregue os XML e clique em "Processar agora".
-O arquivo de saida e gravado na pasta informada pelo YAML da versao (output/<versao>/).
-O log tambem guarda mode="ui:<versao>" para rastreabilidade.
+Na barra lateral selecione a versão desejada, carregue os XML e clique em "Processar agora". O arquivo de saída é gravado na pasta informada pelo YAML da versão (`output/<versao>/`). O log também guarda `mode="ui:<versao>"` para rastreabilidade.
 
-### Configs por versao
+### Configs por versão
 
-Os YAMLs de referencia ficam em:
+Os YAMLs de referência ficam em:
 
-- pipelines/v1/config.yaml
-- pipelines/v2/config.yaml
-- pipelines/enhanced/config.yaml
-- pipelines/super/config.yaml
+- `pipelines/v1/config.yaml`
+- `pipelines/v2/config.yaml`
+- `pipelines/enhanced/config.yaml`
+- `pipelines/super/config.yaml`
 
-Todos compartilham o mesmo cabeçalho Shopify e mantem os defaults:
-Variant Fulfillment Service=manual, Variant Inventory Policy=deny,
-Variant Inventory Tracker=shopify, Variant Requires Shipping=TRUE e
-Variant Taxable=TRUE.
+Todos compartilham o mesmo cabeçalho Shopify e mantêm os defaults: `Variant Fulfillment Service=manual`, `Variant Inventory Policy=deny`, `Variant Inventory Tracker=shopify`, `Variant Requires Shipping=TRUE` e `Variant Taxable=TRUE`.
 
-### Smoke tests rapidos
+### Smoke tests rápidos
 
-Para validar as quatro versoes com os XMLs de exemplo, execute:
+Para validar as quatro versões com os XMLs de exemplo, execute:
 
-`ash
+```bash
 .\.venv\Scripts\python scripts/run_smoke_tests.py
-`
+```
 
-O script gera um CSV por versao e cria 
-eports/scoreboard.csv com o resultado
-(checks de header, variantes unicas, politicas Shopify e regra g/kg).
-
+O script gera um CSV por versão e cria `reports/scoreboard.csv` com o resultado (checks de header, variantes únicas, políticas Shopify e regra g/kg).

--- a/docs/csv-rules.md
+++ b/docs/csv-rules.md
@@ -1,0 +1,32 @@
+# CSV Export Rules
+
+## Weight Handling
+- Capture catalogue weight in kilograms; ignore zero or missing values.
+- When the weight is below 1kg, convert to grams and export `Variant Weight` with `Variant Weight Unit = g` and `Variant Grams` with the gram value.
+- For weights equal or above 1kg, keep the kilogram value, export `Variant Weight Unit = kg`, and format numbers with dot decimals and no thousand separators.
+- Trim numeric strings and leave the unit blank when the weight is not available.
+
+## Critical Metafields
+- The importer maps the following Shopify metafields from the catalogue or product attributes:
+  - `product.metafields.custom.unidade` from the catalogue unit (`unit`) or NF-e units.
+  - `product.metafields.custom.catalogo` from the `catalogo` column.
+  - `product.metafields.custom.dimensoes_do_produto` from `medidas_s_emb`.
+  - `product.metafields.custom.capacidade` from `capacidade__ml_ou_peso_suportado`.
+  - `product.metafields.custom.ncm` from catalogue data when NF-e is empty.
+- All catalog texts are normalised: `_x000D_`, duplicated `\r\n`, and extra spaces are removed before exporting.
+- Dynamic mapping is enabled in both Enhanced and Super configs with identical source columns.
+
+## Composition Content
+- Keep composition only inside the metafield (`product.metafields.custom.composicao`).
+- Do not inject composition texts into `Body (HTML)` when the metafield is populated; descriptions rely on features/infAdProd only.
+
+## Collections and Tags
+- Populate the `Collection` column from the catalogue `collection` value; fallback to the primary `Product Type` when the catalogue is empty.
+- Preserve category tags so automatic collection-by-tag flows remain compatible.
+
+## Metrics Tracking
+- Every run updates `<log_folder>/metrics.json` with the non-empty counts for the critical metafields above plus the total exported rows.
+- The file keeps the latest 50 runs and can be used to monitor catalogue coverage.
+
+## Version Parity
+- Enhanced and Super pipelines share the same dynamic metafield mapping, weight rules, and collection logic. The UI version switch reuses the updated configs.

--- a/pipelines/enhanced/config.yaml
+++ b/pipelines/enhanced/config.yaml
@@ -1,4 +1,4 @@
-﻿paths:
+paths:
   nfe_input_folder: "data/"
   master_data_file: "example_docs/MART-Ficha-tecnica-Biblioteca-Virtual-08-08-2025.xlsx"
   output_folder: "output/enhanced/"
@@ -78,8 +78,12 @@ metafields:
   dynamic_mapping:
     enabled: true
     map:
-      dimensoes_do_produto: "dimensoes"
-      modo_de_uso: "modo_de_uso"
+      unidade: "unit"
+      catalogo: "catalogo"
+      dimensoes_do_produto: "medidas_s_emb"
+      capacidade: "capacidade__ml_ou_peso_suportado"
+      ncm: "ncm"
+      modo_de_uso: "textos"
 
 variants:
   enabled: true
@@ -95,3 +99,4 @@ weights:
   column: "peso"
   unit_column: "un_peso"
   default_unit: "kg"
+

--- a/pipelines/super/config.yaml
+++ b/pipelines/super/config.yaml
@@ -1,4 +1,4 @@
-﻿paths:
+paths:
   nfe_input_folder: "data/"
   master_data_file: "example_docs/MART-Ficha-tecnica-Biblioteca-Virtual-08-08-2025.xlsx"
   output_folder: "output/super/"
@@ -78,10 +78,12 @@ metafields:
   dynamic_mapping:
     enabled: true
     map:
-      dimensoes_do_produto: "dimensoes"
-      modo_de_uso: "modo_de_uso"
-      capacidade: "capacidade"
+      unidade: "unit"
       catalogo: "catalogo"
+      dimensoes_do_produto: "medidas_s_emb"
+      capacidade: "capacidade__ml_ou_peso_suportado"
+      ncm: "ncm"
+      modo_de_uso: "textos"
 
 variants:
   enabled: true
@@ -97,3 +99,4 @@ weights:
   column: "peso"
   unit_column: "un_peso"
   default_unit: "kg"
+

--- a/src/nfe_importer/core/parser.py
+++ b/src/nfe_importer/core/parser.py
@@ -11,7 +11,7 @@ import pandas as pd
 from lxml import etree
 
 from .models import CatalogProduct, InvoiceInfo, NFEItem
-from .utils import normalize_barcode, normalize_sku, safe_float
+from .utils import clean_multiline_text, normalize_barcode, normalize_sku, safe_float
 
 
 LOGGER = logging.getLogger(__name__)
@@ -211,20 +211,49 @@ class CatalogLoader:
             tags: List[str] = []
             raw_tags = data.get("tags")
             if isinstance(raw_tags, str):
-                tags = [tag.strip() for tag in raw_tags.split(",") if tag.strip()]
+                cleaned_tags = clean_multiline_text(raw_tags)
+                tags = [tag.strip() for tag in cleaned_tags.replace("\n", ",").split(",") if tag.strip()]
 
             metafields = {}
             composition_value = data.get("composition")
-            if isinstance(composition_value, str) and composition_value.strip():
-                metafields["composition"] = composition_value.strip()
+            if isinstance(composition_value, str):
+                cleaned_composition = clean_multiline_text(composition_value)
+                if cleaned_composition:
+                    metafields["composition"] = cleaned_composition
 
+            skip_extra_keys = {
+                "sku",
+                "title",
+                "barcode",
+                "vendor",
+                "product_type",
+                "collection",
+                "unit",
+                "ncm",
+                "cest",
+                "weight",
+                "tags",
+                "composition",
+            }
             extra = {}
-            features_value = data.get("features")
-            if isinstance(features_value, str) and features_value.strip():
-                extra["features"] = features_value.strip()
-            price_value = data.get("price")
-            if isinstance(price_value, (int, float)):
-                extra["price"] = float(price_value)
+            for key, value in data.items():
+                if key in skip_extra_keys:
+                    continue
+                if key == "price":
+                    if isinstance(value, (int, float)):
+                        extra["price"] = float(value)
+                    continue
+                if value is None:
+                    continue
+                if isinstance(value, float) and pd.isna(value):
+                    continue
+                if isinstance(value, str):
+                    cleaned_value = clean_multiline_text(value)
+                    if not cleaned_value:
+                        continue
+                    extra[key] = cleaned_value
+                    continue
+                extra[key] = value
 
             products.append(
                 CatalogProduct(
@@ -249,4 +278,7 @@ class CatalogLoader:
 
 
 __all__ = ["NFEParser", "CatalogLoader"]
+
+
+
 

--- a/src/nfe_importer/core/utils.py
+++ b/src/nfe_importer/core/utils.py
@@ -87,6 +87,17 @@ def normalize_barcode(value: Optional[str]) -> Optional[str]:
     return digits or None
 
 
+
+def clean_multiline_text(value: Optional[str]) -> str:
+    """Normalise multiline text by removing control artefacts and extra whitespace."""
+
+    if not value:
+        return ""
+    s = str(value).replace("_x000D_", " ")
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    parts = [" ".join(line.split()).strip() for line in s.split("\n")]
+    return "\n".join([p for p in parts if p])
+
 def slugify(value: str) -> str:
     normalized = normalize_text(value)
     if not normalized:
@@ -144,6 +155,7 @@ def round_money(value: float) -> float:
     return math.floor(value * 100 + 0.5) / 100.0
 
 
+
 __all__ = [
     "ensure_directory",
     "strip_accents",
@@ -158,6 +170,8 @@ __all__ = [
     "dump_json",
     "load_json",
     "round_money",
+    "clean_multiline_text",
     "STOPWORDS_PT",
 ]
+
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,7 +2,13 @@ from pathlib import Path
 
 import pandas as pd
 
-from nfe_importer.config import CSVOutputConfig, MetafieldsConfig, PathsConfig, PricingConfig, Settings
+from nfe_importer.config import (
+    CSVOutputConfig,
+    MetafieldsConfig,
+    PathsConfig,
+    PricingConfig,
+    Settings,
+)
 from nfe_importer.core.generator import CSVGenerator
 from nfe_importer.core.models import CatalogProduct, MatchDecision, NFEItem
 
@@ -20,6 +26,7 @@ def build_settings(tmp_path: Path) -> Settings:
         columns=[
             "Handle",
             "Title",
+            "Body (HTML)",
             "Vendor",
             "Product Type",
             "SKU",
@@ -31,12 +38,44 @@ def build_settings(tmp_path: Path) -> Settings:
             "Compare At Price",
             "Cost per item",
             "Inventory Qty",
-            "Weight",
+            "Variant Weight",
+            "Variant Weight Unit",
+            "Variant Grams",
+            "Collection",
             "Image Src",
         ],
     )
-    metafields = MetafieldsConfig(namespace="custom", keys={"ncm": "ncm", "cfop": "cfop", "unidade": "unidade", "cest": "cest", "composicao": "composicao"})
-    settings = Settings(paths=paths, pricing=PricingConfig(strategy="markup_fixo", markup_factor=2.0), csv_output=csv_config, metafields=metafields)
+    metafields = MetafieldsConfig(
+        namespace="custom",
+        keys={
+            "ncm": "ncm",
+            "cfop": "cfop",
+            "unidade": "unidade",
+            "cest": "cest",
+            "composicao": "composicao",
+            "catalogo": "catalogo",
+            "modo_de_uso": "modo_de_uso",
+            "capacidade": "capacidade",
+            "dimensoes_do_produto": "dimensoes_do_produto",
+        },
+        dynamic_mapping=MetafieldsConfig.DynamicMap(
+            enabled=True,
+            map={
+                "unidade": "unit",
+                "catalogo": "catalogo",
+                "dimensoes_do_produto": "medidas_s_emb",
+                "capacidade": "capacidade__ml_ou_peso_suportado",
+                "ncm": "ncm",
+                "modo_de_uso": "textos",
+            },
+        ),
+    )
+    settings = Settings(
+        paths=paths,
+        pricing=PricingConfig(strategy="markup_fixo", markup_factor=2.0),
+        csv_output=csv_config,
+        metafields=metafields,
+    )
     settings.ensure_folders()
     return settings
 
@@ -53,6 +92,7 @@ def make_decision() -> MatchDecision:
         cest="",
         weight=0.4,
         metafields={"composition": "70% METAL"},
+        extra={"features": "Detalhes decorativos"},
     )
     item = NFEItem(
         invoice_key="TEST",
@@ -80,9 +120,157 @@ def test_csv_generator_creates_file(tmp_path):
 
     assert csv_path.exists()
     assert pendings_path is None
-    assert dataframe.iloc[0]["SKU"] == "08158"
-    assert dataframe.iloc[0]["Price"] == 20.0  # markup_fixo 2.0 * cost 10.0
+    row = dataframe.iloc[0]
+    assert row["SKU"] == "08158"
+    assert row["Price"] == 20.0  # markup_fixo 2.0 * cost 10.0
+    assert row["Variant Weight"] == "400"
+    assert row["Variant Weight Unit"] == "g"
+    assert row["Variant Grams"] == "400"
+    # Body should keep features but avoid duplicating composition metafield
+    assert "Detalhes decorativos" in row["Body (HTML)"]
+    assert "70% METAL" not in row["Body (HTML)"]
 
     output_df = pd.read_csv(csv_path)
     assert output_df.loc[0, "Handle"] != ""
     assert str(output_df.loc[0, "product.metafields.custom.ncm"]).strip() == "73239900"
+
+
+def test_weight_and_metafields_mapping(tmp_path):
+    settings = build_settings(tmp_path)
+    generator = CSVGenerator(settings)
+
+    product_light = CatalogProduct(
+        sku="SKU-L",
+        title="Produto Leve",
+        vendor="Marca",
+        product_type="Categoria A",
+        unit="CX",
+        ncm="1111",
+        weight=0.3,
+        collection=None,
+        metafields={"composition": "Fibra natural"},
+        extra={
+            "features": "Caracteristica leve",
+            "catalogo": "Linha 1",
+            "medidas_s_emb": "10x10x5",
+            "capacidade__ml_ou_peso_suportado": "500 ml",
+            "textos": "Uso diario",
+        },
+    )
+    item_light = NFEItem(
+        invoice_key="R1",
+        item_number=1,
+        sku="SKU-L",
+        description="Produto leve",
+        barcode=None,
+        ncm=product_light.ncm,
+        cest=None,
+        cfop="5102",
+        unit="CX",
+        quantity=1.0,
+        unit_value=15.0,
+        total_value=15.0,
+    )
+
+    product_heavy = CatalogProduct(
+        sku="SKU-H",
+        title="Produto Pesado",
+        vendor="Marca",
+        product_type="Categoria B",
+        unit="UN",
+        ncm="2222",
+        weight=1.25,
+        collection="Colecao Premium",
+        extra={
+            "catalogo": "Linha 2",
+            "medidas_s_emb": "30x20x15",
+            "textos": "Limpar com pano seco",
+        },
+    )
+    item_heavy = NFEItem(
+        invoice_key="R2",
+        item_number=1,
+        sku="SKU-H",
+        description="Produto pesado",
+        barcode=None,
+        ncm=product_heavy.ncm,
+        cest=None,
+        cfop="6102",
+        unit="UN",
+        quantity=1.0,
+        unit_value=40.0,
+        total_value=40.0,
+    )
+
+    df = generator._build_dataframe(
+        [
+            MatchDecision(item=item_light, product=product_light, confidence=1.0, match_source="sku"),
+            MatchDecision(item=item_heavy, product=product_heavy, confidence=1.0, match_source="sku"),
+        ]
+    )
+
+    row_light = df[df["SKU"] == "SKU-L"].iloc[0]
+    assert row_light["Variant Weight"] == "300"
+    assert row_light["Variant Weight Unit"] == "g"
+    assert row_light["Variant Grams"] == "300"
+    assert row_light["Collection"] == "Categoria A"
+    assert row_light["Body (HTML)"] == "Caracteristica leve"
+    assert row_light["product.metafields.custom.catalogo"] == "Linha 1"
+    assert row_light["product.metafields.custom.capacidade"] == "500 ml"
+    assert row_light["product.metafields.custom.dimensoes_do_produto"] == "10x10x5"
+    assert row_light["product.metafields.custom.unidade"] == "CX"
+    assert row_light["product.metafields.custom.ncm"] == "1111"
+
+    row_heavy = df[df["SKU"] == "SKU-H"].iloc[0]
+    assert row_heavy["Variant Weight"] == "1.25"
+    assert row_heavy["Variant Weight Unit"] == "kg"
+    assert row_heavy["Variant Grams"] == "1250"
+    assert row_heavy["Collection"] == "Colecao Premium"
+    assert row_heavy["product.metafields.custom.catalogo"] == "Linha 2"
+    assert row_heavy["product.metafields.custom.unidade"] == "UN"
+    assert row_heavy["product.metafields.custom.ncm"] == "2222"
+    # When no features provided the body may remain empty
+    assert row_heavy["Body (HTML)"] == ""
+
+
+def test_body_html_excludes_composition_when_metafield_present(tmp_path):
+    settings = build_settings(tmp_path)
+    generator = CSVGenerator(settings)
+
+    product = CatalogProduct(
+        sku="SKU-C",
+        title="Produto com composicao",
+        vendor="Marca",
+        product_type="Categoria",
+        unit="UN",
+        weight=0.8,
+        ncm="3333",
+        metafields={"composition": "100% Algodao"},
+        extra={"features": "Toque macio"},
+    )
+    item = NFEItem(
+        invoice_key="R3",
+        item_number=1,
+        sku="SKU-C",
+        description="Produto com composicao",
+        barcode=None,
+        ncm="3333",
+        cest=None,
+        cfop="5102",
+        unit="UN",
+        quantity=1.0,
+        unit_value=25.0,
+        total_value=25.0,
+    )
+
+    df = generator._build_dataframe(
+        [MatchDecision(item=item, product=product, confidence=1.0, match_source="sku")]
+    )
+
+    row = df.iloc[0]
+    assert row["product.metafields.custom.composicao"] == "100% Algodao"
+    assert row["Body (HTML)"] == "Toque macio"
+    assert "Algodao" not in row["Body (HTML)"]
+
+
+

--- a/tests/test_metafields.py
+++ b/tests/test_metafields.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 from nfe_importer.core.generator import CSVGenerator
-from nfe_importer.core.models import CatalogProduct, NFEItem, MatchDecision
+from nfe_importer.core.models import CatalogProduct, MatchDecision, NFEItem
 from nfe_importer.config import Settings
 
 
-def make_settings(tmp_path: Path, enabled=True):
+def make_settings(tmp_path: Path, enabled: bool = True) -> Settings:
     cfg = {
         "paths": {
             "nfe_input_folder": str(tmp_path),
@@ -17,20 +17,27 @@ def make_settings(tmp_path: Path, enabled=True):
         "csv_output": {
             "filename_prefix": "importacao_produtos_",
             "columns": [
-                "Handle","Title","Body (HTML)","Vendor","Tags","Published",
-                "Option1 Name","Option1 Value","Option2 Name","Option2 Value","Option3 Name","Option3 Value",
-                "Variant SKU","Variant Price","Variant Compare At Price","Variant Inventory Qty","Variant Weight","Variant Weight Unit","Variant Requires Shipping","Image Src","Variant Barcode","Variant Grams","Variant Inventory Tracker","Variant Inventory Policy","Variant Fulfillment Service",
-                "product.metafields.custom.unidade","product.metafields.custom.catalogo","product.metafields.custom.dimensoes_do_produto","product.metafields.custom.composicao","product.metafields.custom.capacidade","product.metafields.custom.modo_de_uso","product.metafields.custom.icms","product.metafields.custom.ncm","product.metafields.custom.pis","product.metafields.custom.ipi","product.metafields.custom.cofins","product.metafields.custom.componente_de_kit","product.metafields.custom.resistencia_a_agua",
-                "Variant Taxable","Cost per item","Image Position","Variant Image","Product Category","Type","Collection","Status"
+                "Handle", "Title", "Body (HTML)", "Vendor", "Tags", "Published",
+                "Variant SKU", "Variant Weight", "Variant Weight Unit", "Variant Grams",
+                "product.metafields.custom.unidade", "product.metafields.custom.catalogo",
+                "product.metafields.custom.dimensoes_do_produto", "product.metafields.custom.capacidade",
             ],
         },
         "metafields": {
             "namespace": "custom",
+            "keys": {
+                "unidade": "unidade",
+                "catalogo": "catalogo",
+                "dimensoes_do_produto": "dimensoes_do_produto",
+                "capacidade": "capacidade",
+            },
             "dynamic_mapping": {
                 "enabled": enabled,
                 "map": {
-                    "dimensoes_do_produto": "dimensoes",
-                    "capacidade": "cap",
+                    "unidade": "unit",
+                    "catalogo": "catalogo",
+                    "dimensoes_do_produto": "medidas_s_emb",
+                    "capacidade": "capacidade__ml_ou_peso_suportado",
                 },
             },
         },
@@ -38,20 +45,46 @@ def make_settings(tmp_path: Path, enabled=True):
     return Settings.parse_obj(cfg)
 
 
-def make_decision(extra: dict):
-    product = CatalogProduct(sku="S", title="P", extra=extra)
+def make_decision(extra: dict) -> MatchDecision:
+    product = CatalogProduct(
+        sku="S",
+        title="Produto",
+        unit="CX",
+        extra=extra,
+    )
     item = NFEItem(
-        invoice_key="k", item_number=1, sku="S", description="P",
-        barcode=None, ncm=None, cest=None, cfop=None, unit="UN", quantity=1.0, unit_value=10.0, total_value=10.0,
+        invoice_key="k",
+        item_number=1,
+        sku="S",
+        description="Produto",
+        barcode=None,
+        ncm=None,
+        cest=None,
+        cfop=None,
+        unit="CX",
+        quantity=1.0,
+        unit_value=10.0,
+        total_value=10.0,
     )
     return MatchDecision(item=item, product=product, confidence=1.0, match_source="test")
 
 
-def test_dynamic_metafields_mapping(tmp_path):
+def test_dynamic_metafields_mapping(tmp_path: Path) -> None:
     settings = make_settings(tmp_path, enabled=True)
-    gen = CSVGenerator(settings)
-    df = gen._build_dataframe([make_decision({"dimensoes": "10x10x10", "cap": "2L"})])
+    generator = CSVGenerator(settings)
+    df = generator._build_dataframe(
+        [
+            make_decision(
+                {
+                    "catalogo": "Linha Casa",
+                    "medidas_s_emb": "10x10x10",
+                    "capacidade__ml_ou_peso_suportado": "2L",
+                }
+            )
+        ]
+    )
     row = df.iloc[0]
     assert row["product.metafields.custom.dimensoes_do_produto"] == "10x10x10"
     assert row["product.metafields.custom.capacidade"] == "2L"
-
+    assert row["product.metafields.custom.catalogo"] == "Linha Casa"
+    assert row["product.metafields.custom.unidade"] == "CX"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from nfe_importer.config import Settings
+from nfe_importer.core.pipeline import Processor
+
+
+def make_settings(tmp_path: Path) -> Settings:
+    master_path = tmp_path / "master.xlsx"
+    master_path.touch()
+    cfg = {
+        "paths": {
+            "nfe_input_folder": str(tmp_path / "input"),
+            "master_data_file": str(master_path),
+            "output_folder": str(tmp_path / "output"),
+            "log_folder": str(tmp_path / "logs"),
+            "synonym_cache_file": str(tmp_path / "synonyms.json"),
+        },
+        "csv_output": {
+            "filename_prefix": "test_",
+            "columns": [
+                "product.metafields.custom.unidade",
+                "product.metafields.custom.ncm",
+                "product.metafields.custom.capacidade",
+                "product.metafields.custom.dimensoes_do_produto",
+            ],
+        },
+        "metafields": {
+            "namespace": "custom",
+            "keys": {
+                "unidade": "unidade",
+                "ncm": "ncm",
+                "capacidade": "capacidade",
+                "dimensoes_do_produto": "dimensoes_do_produto",
+            },
+        },
+    }
+    settings = Settings.parse_obj(cfg)
+    settings.ensure_folders()
+    return settings
+
+
+def test_update_metrics_writes_counts(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    processor = object.__new__(Processor)
+    processor.settings = settings
+
+    df = pd.DataFrame(
+        {
+            "product.metafields.custom.unidade": ["CX", ""],
+            "product.metafields.custom.ncm": ["1111", "2222"],
+            "product.metafields.custom.capacidade": ["", "2L"],
+            "product.metafields.custom.dimensoes_do_produto": ["10x10", "20x20"],
+        }
+    )
+
+    processor._update_metrics("RUN123", df)
+
+    metrics_path = settings.paths.log_folder / "metrics.json"
+    data = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert data["runs"][0]["run_id"] == "RUN123"
+    fields = data["runs"][0]["fields"]
+    assert fields["product.metafields.custom.unidade"]["non_empty"] == 1
+    assert fields["product.metafields.custom.ncm"]["non_empty"] == 2
+    assert fields["product.metafields.custom.capacidade"]["non_empty"] == 1
+    assert fields["product.metafields.custom.dimensoes_do_produto"]["non_empty"] == 2
+    assert fields["product.metafields.custom.ncm"]["total"] == 2


### PR DESCRIPTION
Ajusta conversão de peso (kg↔g), preenche Variant Grams e sanitiza números.
Padroniza mapeamento dinâmico de metafields (unidade, NCM, catálogo, dimensões, capacidade) e evita composição duplicada na descrição.
Define Collection pelo catálogo/produto, registra cobertura em metrics.json e documenta regras no docs/csv-rules.md.
Atualiza testes (test_generator, test_metafields, test_metrics) para validar novos cenários.
Testes

python -m pytest